### PR TITLE
fix(puma.rb): heroku公式ドキュメントに従って記法を修正, Qiita記事を参考にrackupに関する記述を削除

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -4,18 +4,17 @@
 # the maximum value specified for Puma. Default is set to 5 threads for minimum
 # and maximum; this matches the default thread size of Active Record.
 #
-threads_count = ENV.fetch("RAILS_MAX_THREADS") { 5 }
-threads threads_count, threads_count
 
-rackup      DefaultRackup
+threads_count = Integer(ENV['RAILS_MAX_THREADS'] || 5)
+threads threads_count, threads_count
 
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.
 #
-port        ENV.fetch("PORT") { 3000 }
+port        ENV['PORT']     || 3000
 
 # Specifies the `environment` that Puma will run in.
 #
-environment ENV.fetch("RAILS_ENV") { "development" }
+environment ENV['RACK_ENV'] || 'development'
 
 # Specifies the `pidfile` that Puma will use.
 pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" }
@@ -26,7 +25,7 @@ pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" }
 # Workers do not work on JRuby or Windows (both of which do not support
 # processes).
 #
-workers ENV.fetch("WEB_CONCURRENCY") { 2 }
+workers Integer(ENV['WEB_CONCURRENCY'] || 2)
 
 # Use the `preload_app!` method when specifying a `workers` number.
 # This directive tells Puma to first boot the application and load code


### PR DESCRIPTION
参考URL
[Rails アプリケーションを Puma Web サーバーでデプロイする](https://devcenter.heroku.com/ja/articles/deploying-rails-applications-with-the-puma-web-server)
[35歳だけどRailsチュートリアルやってみた。[第4版 7章 7.5プロのデプロイ まとめ&解答例]](https://qiita.com/yokoyan/items/caf005acecb0e6aefbec)