### PR TITLE
fix(puma.rb): pidに関する記述をコメントアウト

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -17,7 +17,7 @@ port        ENV['PORT']     || 3000
 environment ENV['RACK_ENV'] || 'development'
 
 # Specifies the `pidfile` that Puma will use.
-pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" }
+# pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" }
 
 # Specifies the number of `workers` to boot in clustered mode.
 # Workers are forked webserver processes. If using threads and workers together


### PR DESCRIPTION
Errno::ENOENT: No such file or directory @ rb_sysopen - tmp/pids/server.pid